### PR TITLE
Renaming release artifacts and CLI from Switchtec to Velocitypci

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,7 +40,7 @@ SYSCONFDIR ?= $(DESTDIR)/etc
 CC=@CC@
 WINDRES=@WINDRES@
 override CPPFLAGS+=@CPPFLAGS@
-override CPPFLAGS+=-I. -Iinc -I$(OBJDIR) -DCOMPLETE_ENV=\"SWITCHTEC_COMPLETE\"
+override CPPFLAGS+=-I. -Iinc -I$(OBJDIR) -DCOMPLETE_ENV=\"VELOCITYPCI_COMPLETE\"
 override CFLAGS+=-g -Wall -Wno-initializer-overrides @CFLAGS@
 DEPFLAGS= -MT $@ -MMD -MP -MF $(OBJDIR)/$*.d
 LDLIBS=@LIBS@ -lm
@@ -56,7 +56,7 @@ endif
 LIB_OBJS=$(addprefix $(OBJDIR)/, $(patsubst %.c,%.o, $(LIB_SRCS)))
 CLI_OBJS=$(addprefix $(OBJDIR)/, $(patsubst %.c,%.o, $(CLI_SRCS)))
 
-STLIBNAME ?= libswitchtec.a
+STLIBNAME ?= libvelocitypci.a
 
 MACHINE=$(shell $(CC) -dumpmachine)
 
@@ -65,19 +65,21 @@ ifeq ($(findstring mingw,$(MACHINE)),mingw)
 endif
 
 ifeq ($(MINGW), YES)
-  EXENAME ?= switchtec.exe
-  INSTEXENAME ?= switchtec
-  SHLIBNAME ?= switchtec.dll
-  IMPLIBNAME ?= libswitchtec.dll.a
+  EXENAME ?= velocitypci.exe
+  INSTEXENAME ?= velocitypci
+  LEGACY_EXENAME ?= switchtec.exe
+  SHLIBNAME ?= velocitypci.dll
+  IMPLIBNAME ?= libvelocitypci.dll.a
   override LDFLAGS += -Wl,--out-implib,$(IMPLIBNAME)
   LDLIBS += -lsetupapi -lws2_32
   SHLDLIBS = $(LDLIBS)
   override CPPFLAGS += -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA
   override CFLAGS += -D__USE_MINGW_ANSI_STDIO -DNCURSES_STATIC
 else
-  EXENAME ?= switchtec
+  EXENAME ?= velocitypci
   INSTEXENAME ?= $(EXENAME)
-  SHLIBNAME ?= libswitchtec.so
+  LEGACY_EXENAME ?= switchtec
+  SHLIBNAME ?= libvelocitypci.so
   IMPLIBNAME ?= $(SHLIBNAME)
   LDCONFIG=ldconfig
   override CFLAGS += -fPIC
@@ -99,14 +101,21 @@ CFLAGS += -Werror
 endif
 
 compile: $(STLIBNAME) $(SHLIBNAME) $(EXENAME) examples/temp
+ifeq ($(UT), yes)
+ifeq ($(MINGW), YES)
+	$(Q)cp -f $(EXENAME) $(LEGACY_EXENAME)
+else
+	$(Q)ln -sf $(EXENAME) $(LEGACY_EXENAME)
+endif
+endif
 
 clean:
-	$(Q)rm -rf $(STLIBNAME) $(SHLIBNAME) $(EXENAME) $(OBJDIR) *.a \
-		examples/temp examples/*.o
+	$(Q)rm -rf $(STLIBNAME) $(SHLIBNAME) $(EXENAME) $(LEGACY_EXENAME) \
+		$(OBJDIR) *.a examples/temp examples/*.o
 
 distclean: clean
 	$(Q)rm -rf config.log config.status *.lib *.exe *.so *.dll build* \
-		Makefile autom4te.cache *.tar* switchtec.spec
+		Makefile autom4te.cache *.tar* velocitypci.spec
 
 $(OBJDIR)/version.h $(OBJDIR)/version.mk: FORCE $(OBJDIR)
 	@$(SHELL_PATH) ./VERSION-GEN
@@ -148,16 +157,25 @@ examples/%: examples/%.o | $(SHLIBNAME)
 	$(Q)$(LINK.o) $^ $(IMPLIBNAME) $(LDLIBS) -o $@
 
 install-bash-completion:
-	@$(NQ) echo "  INSTALL  $(SYSCONFDIR)/bash_completion.d/bash-switchtec-completion.sh"
+	@$(NQ) echo "  INSTALL  $(SYSCONFDIR)/bash_completion.d/bash-velocitypci-completion.sh"
 	$(Q)install -d $(SYSCONFDIR)/bash_completion.d
-	$(Q)install -m 644 -T ./completions/bash-switchtec-completion.sh \
-		$(SYSCONFDIR)/bash_completion.d/switchtec
+	$(Q)install -m 644 -T ./completions/bash-velocitypci-completion.sh \
+		$(SYSCONFDIR)/bash_completion.d/velocitypci
 
 install-bin: compile
 	$(Q)install -d $(BINDIR) $(LIBDIR)
 
 	@$(NQ) echo "  INSTALL  $(BINDIR)/$(INSTEXENAME)"
 	$(Q)install $(EXENAME) $(BINDIR)/$(INSTEXENAME)
+ifeq ($(UT), yes)
+ifeq ($(MINGW), YES)
+	@$(NQ) echo "  COPY     $(BINDIR)/$(LEGACY_EXENAME)"
+	$(Q)cp -f $(BINDIR)/$(INSTEXENAME).exe $(BINDIR)/$(LEGACY_EXENAME)
+else
+	@$(NQ) echo "  SYMLINK  $(BINDIR)/$(LEGACY_EXENAME) -> $(INSTEXENAME)"
+	$(Q)ln -sf $(INSTEXENAME) $(BINDIR)/$(LEGACY_EXENAME)
+endif
+endif
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(STLIBNAME)"
 	$(Q)install -m 0664 $(STLIBNAME) $(LIBDIR)
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(IMPLIBNAME).$(VERSION)"
@@ -184,15 +202,15 @@ ifneq ($(MINGW), YES)
 	$(Q)$(LDCONFIG) $(LIBDIR)
 endif
 
-switchtec.spec: switchtec.spec.in $(OBJDIR)/version.mk
+velocitypci.spec: velocitypci.spec.in $(OBJDIR)/version.mk
 	sed -e 's/@@VERSION@@/$(VERSION)/g' < $< | sed -e 's/@@RELEASE@@/$(RELEASE)/g' > $@+
 	mv $@+ $@
 
-PKG=switchtec-$(VERSION)-$(RELEASE)
-dist: switchtec.spec
+PKG=velocitypci-$(VERSION)-$(RELEASE)
+dist: velocitypci.spec
 	git archive --format=tar --prefix=$(PKG)/ HEAD > $(PKG).tar
 	@echo $(VERSION)-$(RELEASE) > version
-	tar -rf $(PKG).tar --xform="s%^%$(PKG)/%" switchtec.spec version
+	tar -rf $(PKG).tar --xform="s%^%$(PKG)/%" velocitypci.spec version
 	xz -f $(PKG).tar
 	rm -f version
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -170,7 +170,7 @@ install-bin: compile
 ifeq ($(UT), yes)
 ifeq ($(MINGW), YES)
 	@$(NQ) echo "  COPY     $(BINDIR)/$(LEGACY_EXENAME)"
-	$(Q)cp -f $(BINDIR)/$(INSTEXENAME).exe $(BINDIR)/$(LEGACY_EXENAME)
+	$(Q)cp -f $(BINDIR)/$(INSTEXENAME) $(BINDIR)/$(LEGACY_EXENAME)
 else
 	@$(NQ) echo "  SYMLINK  $(BINDIR)/$(LEGACY_EXENAME) -> $(INSTEXENAME)"
 	$(Q)ln -sf $(INSTEXENAME) $(BINDIR)/$(LEGACY_EXENAME)

--- a/cli/cli.rc
+++ b/cli/cli.rc
@@ -23,7 +23,7 @@
 */
 
 #define VER_FILETYPE		VFT_APP
-#define VER_INTERNALNAME_STR	"switchtec.exe"
-#define VER_PRODUCTNAME_STR	"Switchtec Management CLI"
+#define VER_INTERNALNAME_STR	"velocitypci.exe"
+#define VER_PRODUCTNAME_STR	"VelocityPCI Management CLI"
 
 #include "windows/version.rc"

--- a/cli/commands.c
+++ b/cli/commands.c
@@ -83,7 +83,7 @@ static const char *dash_to_underscore(const char *str)
 
 static int print_version(void)
 {
-	fprintf(stderr, "switchtec cli version %s\n", VERSION);
+	fprintf(stderr, "velocitypci cli version %s\n", VERSION);
 	return 0;
 }
 
@@ -117,7 +117,7 @@ static void general_help(const struct subcommand *subcmd,
 
 	print_completions(subcmd->cmds);
 
-	fprintf(stderr, "switchtec-%s\n", VERSION);
+	fprintf(stderr, "velocitypci-%s\n", VERSION);
 
 	usage(subcmd, prog_info);
 

--- a/cli/main.c
+++ b/cli/main.c
@@ -122,7 +122,7 @@ int mfg_handler(const char *optarg, void *value_addr,
 	return switchtec_handler(optarg, value_addr, opt);
 }
 
-#define CMD_DESC_LIST "list all Switchtec devices on this machine"
+#define CMD_DESC_LIST "list all VelocityPCI devices on this machine"
 
 static int list(int argc, char **argv)
 {
@@ -1239,7 +1239,7 @@ done:
 	return ret;
 }
 
-#define CMD_DESC_TEST "test if the Switchtec interface is working"
+#define CMD_DESC_TEST "test if the VelocityPCI interface is working"
 
 static int test(int argc, char **argv)
 {
@@ -2453,7 +2453,7 @@ REGISTER_SUBCMD(subcmd);
 
 static struct prog_info prog_info = {
 	.usage = "<command> [<device>] [OPTIONS]",
-	.desc = "The <device> must be a Switchtec device "
+	.desc = "The <device> must be a VelocityPCI device "
 		"(ex: /dev/switchtec0)",
 };
 

--- a/completions/bash-velocitypci-completion.sh
+++ b/completions/bash-velocitypci-completion.sh
@@ -1,10 +1,10 @@
 
-_switchtec_comp () {
+_velocitypci_comp () {
         local cur prev words cword
 	_init_completion || return
 	local compargs=""
 
-	opts=$(SWITCHTEC_COMPLETE=1 ${words[*]:0:$cword})
+	opts=$(VELOCITYPCI_COMPLETE=1 ${words[*]:0:$cword})
 	compfile=$?
 
 	if [ $compfile -eq 2 ]; then
@@ -17,5 +17,5 @@ _switchtec_comp () {
 	return 0
 }
 
-complete -F _switchtec_comp switchtec
-complete -F _switchtec_comp ./switchtec
+complete -F _velocitypci_comp velocitypci
+complete -F _velocitypci_comp ./velocitypci

--- a/dist/mkinstaller
+++ b/dist/mkinstaller
@@ -56,9 +56,9 @@ function build()
 	./configure --host $host
 	make clean
 	make
-	cp switchtec.exe switchtec.dll libswitchtec* dist/$host
-	strip dist/$host/switchtec.exe
-	strip dist/$host/switchtec.dll
+	cp velocitypci.exe velocitypci.dll libvelocitypci* dist/$host
+	strip dist/$host/velocitypci.exe
+	strip dist/$host/velocitypci.dll
 
 	cp /$pth/bin/libwinpthread-1.dll dist/$host
 
@@ -69,4 +69,4 @@ function build()
 build i686-w64-mingw32 mingw32
 build x86_64-w64-mingw32 mingw64
 
-iscc switchtec.iss
+iscc velocitypci.iss

--- a/dist/velocitypci.iss
+++ b/dist/velocitypci.iss
@@ -1,40 +1,40 @@
-#define AppVersionStr GetFileProductVersion("x86_64-w64-mingw32/switchtec.exe")
-#define AppVersion GetFileVersion("x86_64-w64-mingw32/switchtec.exe")
+#define AppVersionStr GetFileProductVersion("x86_64-w64-mingw32/velocitypci.exe")
+#define AppVersion GetFileVersion("x86_64-w64-mingw32/velocitypci.exe")
 
 [Setup]
-AppName=Switchtec Management CLI
+AppName=VelocityPCI Management CLI
 AppVersion={#AppVersionStr}
 VersionInfoVersion={#AppVersion}
-DefaultDirName={pf}\Switchtec
+DefaultDirName={pf}\VelocityPCI
 Compression=lzma2
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64
 OutputDir=.
-OutputBaseFilename=switchtec-user-{#AppVersionStr}
+OutputBaseFilename=velocitypci-cli-{#AppVersionStr}
 ChangesEnvironment=true
 DisableWelcomePage=no
 
 [Files]
-Source: "x86_64-w64-mingw32\switchtec.exe"; DestDir: "{app}"; \
+Source: "x86_64-w64-mingw32\velocitypci.exe"; DestDir: "{app}"; \
 	Check: Is64BitInstallMode
 Source: "x86_64-w64-mingw32\libwinpthread-1.dll"; DestDir: "{app}"; \
 	Check: Is64BitInstallMode
 
 ; Place all x86 files here, first one should be marked 'solidbreak'
-Source: "i686-w64-mingw32\switchtec.exe";  DestDir: "{app}"; \
+Source: "i686-w64-mingw32\velocitypci.exe";  DestDir: "{app}"; \
 	Check: not Is64BitInstallMode; Flags: solidbreak
 Source: "i686-w64-mingw32\libwinpthread-1.dll"; DestDir: "{app}"; \
 	Check: not Is64BitInstallMode
 
 Source: "less.exe"; DestDir: "{app}"; Flags: solidbreak
 
-Source: "x86_64-w64-mingw32\switchtec.dll"; DestDir: "{app}\x64"
-Source: "x86_64-w64-mingw32\libswitchtec.a"; DestDir: "{app}\x64"
-Source: "x86_64-w64-mingw32\libswitchtec.dll.a"; DestDir: "{app}\x64"
+Source: "x86_64-w64-mingw32\velocitypci.dll"; DestDir: "{app}\x64"
+Source: "x86_64-w64-mingw32\libvelocitypci.a"; DestDir: "{app}\x64"
+Source: "x86_64-w64-mingw32\libvelocitypci.dll.a"; DestDir: "{app}\x64"
 
-Source: "i686-w64-mingw32\switchtec.dll"; DestDir: "{app}\x32"
-Source: "i686-w64-mingw32\libswitchtec.a"; DestDir: "{app}\x32"
-Source: "i686-w64-mingw32\libswitchtec.dll.a"; DestDir: "{app}\x32"
+Source: "i686-w64-mingw32\velocitypci.dll"; DestDir: "{app}\x32"
+Source: "i686-w64-mingw32\libvelocitypci.a"; DestDir: "{app}\x32"
+Source: "i686-w64-mingw32\libvelocitypci.dll.a"; DestDir: "{app}\x32"
 
 Source: "..\inc\switchtec\*"; DestDir: "{app}\inc\switchtec"; \
 	Flags: ignoreversion recursesubdirs

--- a/lib/lib.rc
+++ b/lib/lib.rc
@@ -23,7 +23,7 @@
 */
 
 #define VER_FILETYPE		VFT_DLL
-#define VER_INTERNALNAME_STR	"switchtec.dll"
-#define VER_PRODUCTNAME_STR	"Switchtec Management Library"
+#define VER_INTERNALNAME_STR	"velocitypci.dll"
+#define VER_PRODUCTNAME_STR	"VelocityPCI Management Library"
 
 #include "windows/version.rc"

--- a/velocitypci.spec.in
+++ b/velocitypci.spec.in
@@ -1,17 +1,17 @@
-Name: 		switchtec
+Name: 		velocitypci
 Version: 	@@VERSION@@
 Release: 	@@RELEASE@@%{?dist}
 Summary:  	Userspace application and library  for the Microsemi PCIe Switch
 License: 	MIT
 Group: 		Development/Tools
-URL: 		https://github.com/Microsemi/switchtec-user
-Source: 	switchtec-@@VERSION@@-@@RELEASE@@.tar.xz
-Provides:	switchtec
+URL: 		https://github.com/MicrochipTech/velocitypci-cli
+Source: 	velocitypci-@@VERSION@@-@@RELEASE@@.tar.xz
+Provides:	velocitypci
 BuildRoot:	%{_tmppath}/%{name}-%{version}-root
 
 %description
 This application and C library allows for communicating with
-Microsemi's Switchtec management interface.
+Microchip's VelocityPCI management interface.
 
 This provides the following features:
 
@@ -25,7 +25,7 @@ This provides the following features:
 * A simple ncurses GUI that shows salient information for the switch
 
 %prep
-%setup -n switchtec-@@VERSION@@-@@RELEASE@@
+%setup -n velocitypci-@@VERSION@@-@@RELEASE@@
 
 %build
 %configure --with-curses
@@ -43,10 +43,10 @@ make install-pkg DESTDIR=%{buildroot}
 
 %files
 %defattr(-,root,root)
-/usr/local/bin/switchtec
-/usr/local/lib/libswitchtec.*
+/usr/local/bin/velocitypci
+/usr/local/lib/libvelocitypci.*
 /usr/local/include/switchtec/*.*
-/etc/bash_completion.d/switchtec
+/etc/bash_completion.d/velocitypci
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Summary                                                                                                                                                                                                          
 
- Rename CLI binary from switchtec to velocitypci                                                                                                                                                                
- Rename libraries: libswitchtec.{a,so,dll} → libvelocitypci.{a,so,dll}
- Update version output, help text, bash completion, and packaging to reflect VelocityPCI branding                                                                                                               
- Add LEGACY_EXENAME build option to produce backward-compatible switchtec binary                                                                                                                                
                                                                                                                                                                                                                 
Kernel/driver compatibility                                                                                                                                                                                      
                                                                                                                                                                                                                 
- No changes to kernel ABI headers, C API symbols, #include paths, or /dev/switchtec* device paths                                                                            